### PR TITLE
CSV Import: Robust Parser for Quoted Fields (round‑trip safe)

### DIFF
--- a/pages/api/csv/guests.ts
+++ b/pages/api/csv/guests.ts
@@ -1,40 +1,67 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { withAuth } from '../../../lib/apiAuth'
 import { supabase } from '../../../lib/supabase'
+import { parseCSV } from '../../../utils/csv'
 
 export default withAuth(async (req: NextApiRequest, res: NextApiResponse, auth) => {
   const ownerId = auth.user?.id || 'demo-owner'
+
   if (req.method === 'GET') {
-    const { data, error } = await supabase.from('guests').select('name,email,phone,notes').eq('owner_id', ownerId).order('name')
+    const { data, error } = await supabase
+      .from('guests')
+      .select('name,email,phone,notes')
+      .eq('owner_id', ownerId)
+      .order('name')
     if (error) return res.status(500).json({ error: error.message })
     const headers = ['name', 'email', 'phone', 'notes']
-    const csv = [headers.join(','), ...(data || []).map((r) => headers.map((h) => `"${String((r as any)[h] ?? '').replace(/"/g, '""')}"`).join(','))].join('\n')
+    const csv = [
+      headers.join(','),
+      ...(data || []).map((r) =>
+        headers.map((h) => `"${String((r as any)[h] ?? '').replace(/"/g, '""')}"`).join(',')
+      ),
+    ].join('\n')
     res.setHeader('Content-Type', 'text/csv')
     res.setHeader('Content-Disposition', 'attachment; filename="guests.csv"')
     res.status(200).send(csv)
     return
   }
+
   if (req.method === 'POST') {
     const { csv } = req.body as { csv?: string }
     if (!csv) return res.status(400).json({ error: 'Missing CSV content' })
-    const lines = csv.split(/\r?\n/).filter(Boolean)
-    const [headerLine, ...rows] = lines
-    const headers = headerLine.split(',').map((h) => h.trim())
-    const idx = { name: headers.indexOf('name'), email: headers.indexOf('email'), phone: headers.indexOf('phone'), notes: headers.indexOf('notes') }
-    if (idx.name < 0 || idx.email < 0) return res.status(400).json({ error: 'name and email columns are required' })
-    let ok = 0, fail = 0
-    for (const row of rows) {
-      const cols = row.split(',')
-      const name = cols[idx.name]?.replace(/^"|"$/g, '')
-      const email = cols[idx.email]?.replace(/^"|"$/g, '')
-      const phone = idx.phone >= 0 ? cols[idx.phone]?.replace(/^"|"$/g, '') : undefined
-      const notes = idx.notes >= 0 ? cols[idx.notes]?.replace(/^"|"$/g, '') : undefined
+
+    const table = parseCSV(csv)
+    if (!table.length) return res.status(400).json({ error: 'Empty CSV' })
+    const header = table[0].map((h) => h.trim().toLowerCase())
+    const idx = {
+      name: header.indexOf('name'),
+      email: header.indexOf('email'),
+      phone: header.indexOf('phone'),
+      notes: header.indexOf('notes'),
+    }
+    if (idx.name < 0 || idx.email < 0) {
+      return res.status(400).json({ error: 'CSV must include headers: name,email[,phone,notes]' })
+    }
+
+    let ok = 0
+    let fail = 0
+    for (let r = 1; r < table.length; r++) {
+      const cols = table[r]
+      if (!cols || cols.length === 0 || cols.every((c) => c.trim() === '')) continue
+      const name = (cols[idx.name] ?? '').trim()
+      const email = (cols[idx.email] ?? '').trim()
+      const phone = idx.phone >= 0 ? (cols[idx.phone] ?? '').trim() : undefined
+      const notes = idx.notes >= 0 ? (cols[idx.notes] ?? '').trim() : undefined
       if (!name || !email) { fail++; continue }
-      const { error } = await supabase.from('guests').insert({ name, email, phone, notes, owner_id: ownerId })
-      if (error) fail++; else ok++
+      const { error } = await supabase
+        .from('guests')
+        .insert({ name, email, phone, notes, owner_id: ownerId })
+      if (error) fail++
+      else ok++
     }
     return res.status(200).json({ message: `Imported ${ok} guests; ${fail} failed.` })
   }
+
   res.setHeader('Allow', ['GET', 'POST'])
   res.status(405).end('Method Not Allowed')
 })

--- a/utils/csv.ts
+++ b/utils/csv.ts
@@ -1,0 +1,74 @@
+// Minimal CSV parser that supports:
+// - Commas inside quoted fields
+// - Double quote escaping ("") inside quoted fields
+// - CRLF or LF newlines
+// Returns an array of rows; each row is an array of string cells
+export function parseCSV(input: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let cell = ''
+  let i = 0
+  const s = input
+  const n = s.length
+  let inQuotes = false
+
+  while (i < n) {
+    const ch = s[i]
+
+    if (inQuotes) {
+      if (ch === '"') {
+        // Lookahead for escaped quote
+        if (i + 1 < n && s[i + 1] === '"') {
+          cell += '"'
+          i += 2
+          continue
+        } else {
+          inQuotes = false
+          i++
+          continue
+        }
+      } else {
+        cell += ch
+        i++
+        continue
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true
+        i++
+        continue
+      }
+      if (ch === ',') {
+        row.push(cell)
+        cell = ''
+        i++
+        continue
+      }
+      if (ch === '\n' || ch === '\r') {
+        // Finish cell and row
+        row.push(cell)
+        cell = ''
+        // Skip paired CRLF/LFCR
+        if (ch === '\r' && i + 1 < n && s[i + 1] === '\n') i++
+        if (ch === '\n' && i + 1 < n && s[i + 1] === '\r') i++
+        rows.push(row)
+        row = []
+        i++
+        continue
+      }
+      cell += ch
+      i++
+    }
+  }
+
+  // Push last cell/row
+  row.push(cell)
+  rows.push(row)
+
+  // Trim any trailing empty last row caused by terminal newline
+  if (rows.length && rows[rows.length - 1].length === 1 && rows[rows.length - 1][0] === '') {
+    rows.pop()
+  }
+  return rows
+}
+


### PR DESCRIPTION
Fix import to parse quoted CSV correctly so files exported by our API round‑trip without corruption.\n\nChanges\n- Add utils/csv minimal parser (supports commas in quotes, escaped quotes, CRLF/LF)\n- Use parseCSV in /api/csv/guests import path instead of split(',')\n\nTesting\n- Export guests via /api/csv/guests, then re‑import the same file (names/notes with commas work).\n\nStatus\n- gh pr view $PR --json statusCheckRollup | jq .\n- SHA=$(gh pr view $PR --json headRefOid -q .headRefOid); gh api repos/stevie86/hostelpulse/commits/$SHA/status | jq .