### PR TITLE
feat(csv): guest dry-run preview

### DIFF
--- a/changes/2025-09-21-session.md
+++ b/changes/2025-09-21-session.md
@@ -13,6 +13,7 @@
 - Replaced plain `<a>` navigation with Next `Link` or accessible anchors in dashboard, footer, and navbar.
 - Removed unused imports/variables and deprecated CSS link injection in the blog page.
 - Confirmed `npm run lint` completes with zero warnings or errors.
+- Added guest CSV dry-run preview with summary/issue reporting and confirmed import upsert flow (PR #37).
 
 ## Notes
 - Npm install for Jest tooling timed out in sandbox; revisit when network allowances improve.
@@ -20,4 +21,5 @@
 - Next focus: craft coverage (manual or Jest-based) for booking partial updates once tooling is available.
 - Prism theme lazy-loading was removed from `pages/blog/[slug].tsx`; restore with a compliant approach if syntax highlighting is required later.
 - Social media links in `components/Footer.tsx` now open in a new tab with proper rel attributes.
+- Guest import manual tests: missing email/name skipped with issues list; mix of new/existing emails updates counts and upserts records.
 

--- a/components/CSVImportExport.tsx
+++ b/components/CSVImportExport.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import Button from './Button'
 
@@ -7,11 +7,41 @@ interface CSVImportExportProps {
   onImportSuccess?: (result: any) => void
 }
 
+type ImportSummary = {
+  totalRows: number
+  ready: number
+  toInsert: number
+  toUpdate: number
+  skipped: number
+}
+
+type ImportIssue = {
+  row: number
+  email?: string
+  reason: string
+}
+
+type PreviewRow = {
+  row: number
+  name: string
+  email: string
+  phone?: string
+  notes?: string
+  action: 'insert' | 'update'
+}
+
 export default function CSVImportExport({ type, onImportSuccess }: CSVImportExportProps) {
   const [importing, setImporting] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [importResult, setImportResult] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [summary, setSummary] = useState<ImportSummary | null>(null)
+  const [issues, setIssues] = useState<ImportIssue[]>([])
+  const [preview, setPreview] = useState<PreviewRow[]>([])
+  const [pendingCsv, setPendingCsv] = useState<string | null>(null)
+  const [mode, setMode] = useState<'idle' | 'preview' | 'committed'>('idle')
+
+  const isGuestImport = type === 'guests'
 
   async function handleExport() {
     setExporting(true)
@@ -47,24 +77,85 @@ export default function CSVImportExport({ type, onImportSuccess }: CSVImportExpo
     setImporting(true)
     setError(null)
     setImportResult(null)
+    setSummary(null)
+    setIssues([])
+    setPreview([])
     try {
       const text = await file.text()
-      const response = await fetch(`/api/csv/${type}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ csv: text }),
-      })
-      const result = await response.json()
-      if (!response.ok) throw new Error(result.error || 'Import failed')
-      setImportResult(result.message)
-      onImportSuccess?.(result)
+      if (isGuestImport) {
+        const response = await fetch(`/api/csv/${type}?dryRun=1`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ csv: text }),
+        })
+        const result = await response.json()
+        if (!response.ok) throw new Error(result.error || 'Import failed')
+        setSummary(result.summary)
+        setIssues(result.issues || [])
+        setPreview(result.preview || [])
+        setImportResult('Preview ready. Review details below, then confirm import.')
+        setPendingCsv(text)
+        setMode('preview')
+      } else {
+        const response = await fetch(`/api/csv/${type}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ csv: text }),
+        })
+        const result = await response.json()
+        if (!response.ok) throw new Error(result.error || 'Import failed')
+        setImportResult(result.message)
+        onImportSuccess?.(result)
+        setMode('committed')
+      }
     } catch (e: any) {
       setError(e.message || 'Import failed. Please check your CSV format.')
+      setPendingCsv(null)
+      setMode('idle')
     } finally {
       setImporting(false)
       event.target.value = ''
     }
   }
+
+  async function handleConfirmImport() {
+    if (!pendingCsv) return
+    setImporting(true)
+    setError(null)
+    try {
+      const response = await fetch(`/api/csv/${type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csv: pendingCsv }),
+      })
+      const result = await response.json()
+      if (!response.ok) throw new Error(result.error || 'Import failed')
+      setImportResult(result.message || 'Import completed successfully.')
+      setSummary(result.summary)
+      setIssues(result.issues || [])
+      setPreview(result.preview || preview)
+      setMode('committed')
+      setPendingCsv(null)
+      onImportSuccess?.(result)
+    } catch (e: any) {
+      setError(e.message || 'Import failed. Please check your CSV format.')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const hasPreview = isGuestImport && preview.length > 0
+
+  const summaryItems = useMemo(() => {
+    if (!summary) return []
+    return [
+      { label: 'Total rows', value: summary.totalRows },
+      { label: 'Ready to import', value: summary.ready },
+      { label: 'New guests', value: summary.toInsert },
+      { label: 'Updates', value: summary.toUpdate },
+      { label: 'Skipped', value: summary.skipped },
+    ]
+  }, [summary])
 
   return (
     <Container>
@@ -81,10 +172,73 @@ export default function CSVImportExport({ type, onImportSuccess }: CSVImportExpo
         </FileInputWrapper>
       </Actions>
       {error && <ErrorMessage>{error}</ErrorMessage>}
-      {importResult && <SuccessMessage>{importResult}</SuccessMessage>}
+      {importResult && !error && <SuccessMessage>{importResult}</SuccessMessage>}
+      {summaryItems.length > 0 && (
+        <SummaryGrid>
+          {summaryItems.map((item) => (
+            <SummaryItem key={item.label}>
+              <span>{item.label}</span>
+              <strong>{item.value}</strong>
+            </SummaryItem>
+          ))}
+        </SummaryGrid>
+      )}
+      {hasPreview && (
+        <PreviewTable>
+          <thead>
+            <tr>
+              <th>Row</th>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Notes</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {preview.map((row) => (
+              <tr key={row.row}>
+                <td>{row.row}</td>
+                <td>{row.name}</td>
+                <td>{row.email}</td>
+                <td>{row.phone || '—'}</td>
+                <td>{row.notes || '—'}</td>
+                <td>{row.action === 'insert' ? 'New' : 'Update'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </PreviewTable>
+      )}
+      {issues.length > 0 && (
+        <IssuesPanel>
+          <strong>Skipped rows:</strong>
+          <ul>
+            {issues.map((issue, idx) => (
+              <li key={`${issue.row}-${idx}`}>
+                Row {issue.row}{issue.email ? ` (${issue.email})` : ''}: {issue.reason}
+              </li>
+            ))}
+          </ul>
+        </IssuesPanel>
+      )}
+      {isGuestImport && mode === 'preview' && (
+        <Button
+          onClick={handleConfirmImport}
+          disabled={importing || !pendingCsv}
+          style={{ marginTop: '1rem' }}
+        >
+          {importing ? 'Importing...' : 'Confirm Import'}
+        </Button>
+      )}
       <Instructions>
         <strong>CSV Format:</strong>
-        {type === 'guests' ? <div>name, email, phone, notes</div> : <div>Export only (import coming soon)</div>}
+        {type === 'guests' ? (
+          <div>
+            Columns: <code>name</code>, <code>email</code>, optional <code>phone</code>, <code>notes</code>. Duplicate emails are deduped; missing name/email rows are skipped.
+          </div>
+        ) : (
+          <div>Export only (import coming soon)</div>
+        )}
       </Instructions>
     </Container>
   )
@@ -117,4 +271,56 @@ const FileInputLabel = styled.label`
 const ErrorMessage = styled.div` color: #b91c1c; font-size: 1.3rem; margin-bottom: 1rem; padding: 0.8rem; background: #fef2f2; border-radius: 0.4rem; border: 1px solid #fecaca; `
 const SuccessMessage = styled.div` color: #059669; font-size: 1.3rem; margin-bottom: 1rem; padding: 0.8rem; background: #f0fdf4; border-radius: 0.4rem; border: 1px solid #bbf7d0; `
 const Instructions = styled.div` font-size: 1.2rem; opacity: 0.7; strong { display: block; margin-bottom: 0.4rem; opacity: 1; } `
+const SummaryGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+`
+const SummaryItem = styled.div`
+  background: rgb(var(--cardBackground));
+  border: 1px solid rgb(var(--border));
+  border-radius: 0.6rem;
+  padding: 0.8rem;
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.2rem;
 
+  strong {
+    font-weight: 600;
+  }
+`
+const PreviewTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+
+  th, td {
+    border: 1px solid rgb(var(--border));
+    padding: 0.6rem;
+    text-align: left;
+  }
+
+  th {
+    background: rgba(var(--primary), 0.08);
+    font-weight: 600;
+  }
+`
+const IssuesPanel = styled.div`
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 0.6rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+
+  ul {
+    margin: 0.6rem 0 0;
+    padding-left: 1.4rem;
+  }
+
+  li + li {
+    margin-top: 0.2rem;
+  }
+`

--- a/pages/api/csv/guests.ts
+++ b/pages/api/csv/guests.ts
@@ -3,6 +3,26 @@ import { withAuth } from '../../../lib/apiAuth'
 import { supabase } from '../../../lib/supabase'
 import { parseCSV } from '../../../utils/csv'
 
+type GuestRow = {
+  rowNumber: number
+  name: string
+  email: string
+  originalEmail: string
+  phone?: string
+  notes?: string
+}
+
+type ImportIssue = {
+  row: number
+  email?: string
+  reason: string
+}
+
+function normalize(value?: string | null) {
+  const trimmed = (value ?? '').trim()
+  return trimmed.length ? trimmed : undefined
+}
+
 export default withAuth(async (req: NextApiRequest, res: NextApiResponse, auth) => {
   const ownerId = auth.user?.id || 'demo-owner'
 
@@ -27,11 +47,13 @@ export default withAuth(async (req: NextApiRequest, res: NextApiResponse, auth) 
   }
 
   if (req.method === 'POST') {
+    const dryRun = req.query.dryRun === '1'
     const { csv } = req.body as { csv?: string }
     if (!csv) return res.status(400).json({ error: 'Missing CSV content' })
 
     const table = parseCSV(csv)
     if (!table.length) return res.status(400).json({ error: 'Empty CSV' })
+
     const header = table[0].map((h) => h.trim().toLowerCase())
     const idx = {
       name: header.indexOf('name'),
@@ -43,26 +65,107 @@ export default withAuth(async (req: NextApiRequest, res: NextApiResponse, auth) 
       return res.status(400).json({ error: 'CSV must include headers: name,email[,phone,notes]' })
     }
 
-    let ok = 0
-    let fail = 0
+    const issues: ImportIssue[] = []
+    const rows: GuestRow[] = []
+    const seenEmails = new Set<string>()
+
     for (let r = 1; r < table.length; r++) {
+      const rowNumber = r + 1
       const cols = table[r]
       if (!cols || cols.length === 0 || cols.every((c) => c.trim() === '')) continue
-      const name = (cols[idx.name] ?? '').trim()
-      const email = (cols[idx.email] ?? '').trim()
-      const phone = idx.phone >= 0 ? (cols[idx.phone] ?? '').trim() : undefined
-      const notes = idx.notes >= 0 ? (cols[idx.notes] ?? '').trim() : undefined
-      if (!name || !email) { fail++; continue }
-      const { error } = await supabase
-        .from('guests')
-        .insert({ name, email, phone, notes, owner_id: ownerId })
-      if (error) fail++
-      else ok++
+
+      const name = normalize(cols[idx.name])
+      const emailRaw = normalize(cols[idx.email])
+      const phone = idx.phone >= 0 ? normalize(cols[idx.phone]) : undefined
+      const notes = idx.notes >= 0 ? normalize(cols[idx.notes]) : undefined
+
+      if (!name || !emailRaw) {
+        issues.push({ row: rowNumber, reason: 'Missing name or email' })
+        continue
+      }
+
+      const email = emailRaw.toLowerCase()
+      if (seenEmails.has(email)) {
+        issues.push({ row: rowNumber, email: emailRaw, reason: 'Duplicate email in CSV' })
+        continue
+      }
+      seenEmails.add(email)
+
+      rows.push({ rowNumber, name, email, originalEmail: emailRaw, phone, notes })
     }
-    return res.status(200).json({ message: `Imported ${ok} guests; ${fail} failed.` })
+
+    const uniqueEmails = rows.map((row) => row.email)
+    let existingEmails = new Set<string>()
+    if (uniqueEmails.length) {
+      const { data: existing, error: existingError } = await supabase
+        .from('guests')
+        .select('email')
+        .eq('owner_id', ownerId)
+        .in('email', uniqueEmails)
+
+      if (existingError) {
+        return res.status(500).json({ error: existingError.message })
+      }
+      existingEmails = new Set((existing || []).map((g) => (g.email || '').toLowerCase()))
+    }
+
+    const toUpdate = rows.filter((row) => existingEmails.has(row.email))
+    const toInsert = rows.filter((row) => !existingEmails.has(row.email))
+
+    const summary = {
+      totalRows: table.length - 1,
+      ready: rows.length,
+      toInsert: toInsert.length,
+      toUpdate: toUpdate.length,
+      skipped: issues.length,
+    }
+
+    const preview = rows.slice(0, 10).map((row) => ({
+      name: row.name,
+      email: row.originalEmail,
+      phone: row.phone,
+      notes: row.notes,
+      action: existingEmails.has(row.email) ? 'update' : 'insert',
+      row: row.rowNumber,
+    }))
+
+    if (dryRun) {
+      return res.status(200).json({ mode: 'dryRun', summary, preview, issues })
+    }
+
+    if (!rows.length) {
+      return res.status(200).json({
+        mode: 'commit',
+        summary,
+        issues,
+        message: 'No valid rows to import',
+      })
+    }
+
+    const payload = rows.map((row) => ({
+      owner_id: ownerId,
+      name: row.name,
+      email: row.email,
+      phone: row.phone ?? null,
+      notes: row.notes ?? null,
+    }))
+
+    const { error: upsertError } = await supabase
+      .from('guests')
+      .upsert(payload, { onConflict: 'owner_id,email' })
+
+    if (upsertError) {
+      return res.status(500).json({ error: upsertError.message })
+    }
+
+    return res.status(200).json({
+      mode: 'commit',
+      summary,
+      issues,
+      message: `Imported ${toInsert.length} new guest${toInsert.length === 1 ? '' : 's'} and updated ${toUpdate.length}. Skipped ${issues.length}.`,
+    })
   }
 
   res.setHeader('Allow', ['GET', 'POST'])
   res.status(405).end('Method Not Allowed')
 })
-


### PR DESCRIPTION
## Summary
- add dry-run preview + confirm workflow to guest CSV import component
- surface per-row summary + issues and reuse server-provided dedupe counts
- enhance  to support dry-run, dedupe by email, and upsert on commit

## Testing
- npm run lint *(legacy warnings remain; no new errors introduced)*
- manual: upload guest CSV with missing fields (skips row + shows issues)
- manual: dry-run then confirm import for mix of new/existing emails; verified updates + summary