### PR TITLE
ui: add management stats and refresh controls

### DIFF
--- a/changes/2025-09-24-session.md
+++ b/changes/2025-09-24-session.md
@@ -6,9 +6,11 @@
 - Merged guest CSV dry-run flow (#37) and synced `main`.
 - Implemented bookings CSV dry-run/commit API (`pages/api/csv/bookings.ts`) with overlap detection and validation.
 - Extended `components/CSVImportExport` to support bookings preview, confirmation, and summary messaging.
+- Refreshed bookings/guests/rooms management pages with live stats, refresh controls, and pending-callouts for faster operator triage.
 
 ## Notes
 - Branch protection left relaxed (0 required reviews) per solo workflow preference.
 - Bookings import now requires guests/rooms/beds to exist; overlapping or incomplete rows are reported in issues list.
-- Next focus: wire management UI updates (conflict banners, quick actions refresh) and expand regression checklist per sprint plan.
+- Management views now expose quick metrics (totals, arrivals today, beds count) and explicit refresh buttons after imports.
+- Next focus: expand regression checklist and document import → management → audit QA flow per sprint plan.
 

--- a/pages/bookings.tsx
+++ b/pages/bookings.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import { isToday } from 'date-fns'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
+import Button from 'components/Button'
 import Container from 'components/Container'
 import SectionTitle from 'components/SectionTitle'
 
@@ -39,10 +41,46 @@ export default function BookingsPage() {
     }
   }
 
+  const summary = useMemo(() => {
+    if (!bookings.length) {
+      return { total: 0, confirmed: 0, pending: 0, arrivalsToday: 0, departuresToday: 0 }
+    }
+
+    let confirmed = 0
+    let pending = 0
+    let arrivalsToday = 0
+    let departuresToday = 0
+    bookings.forEach((booking) => {
+      if (booking.status === 'confirmed') confirmed += 1
+      if (booking.status === 'pending') pending += 1
+      if (isToday(new Date(booking.check_in))) arrivalsToday += 1
+      if (isToday(new Date(booking.check_out))) departuresToday += 1
+    })
+    return {
+      total: bookings.length,
+      confirmed,
+      pending,
+      arrivalsToday,
+      departuresToday,
+    }
+  }, [bookings])
+
   return (
       <Container>
         <Wrapper>
           <SectionTitle>Bookings</SectionTitle>
+          <ActionBar>
+            <Stats>
+              <StatBubble>All: {summary.total}</StatBubble>
+              <StatBubble data-tone="ok">Confirmed: {summary.confirmed}</StatBubble>
+              <StatBubble data-tone="warn">Pending: {summary.pending}</StatBubble>
+              <StatBubble data-tone="info">Arrivals today: {summary.arrivalsToday}</StatBubble>
+              <StatBubble data-tone="info">Departures today: {summary.departuresToday}</StatBubble>
+            </Stats>
+            <Button onClick={load} disabled={loading} type="button">
+              {loading ? 'Refreshing…' : 'Refresh list'}
+            </Button>
+          </ActionBar>
           {loading ? (
             <Small>Loading bookings...</Small>
           ) : error ? (
@@ -73,6 +111,9 @@ export default function BookingsPage() {
                     <Label>Status</Label>
                     <Status data-status={b.status}>{b.status}</Status>
                   </Row>
+                  {b.status === 'pending' && (
+                    <Callout data-tone="warn">Action needed: pending confirmation</Callout>
+                  )}
                   {b.notes && (
                     <Row>
                       <Label>Notes</Label>
@@ -90,6 +131,14 @@ export default function BookingsPage() {
 
 const Wrapper = styled.div`
   padding: 2rem 0;
+`
+const ActionBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 `
 const Small = styled.p`
   opacity: 0.7;
@@ -123,4 +172,44 @@ const Status = styled.div`
   &[data-status='confirmed'] { color: #047857; }
   &[data-status='pending'] { color: #92400e; }
   &[data-status='cancelled'] { color: #b91c1c; }
+`
+const Callout = styled.div`
+  margin-top: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.6rem;
+  font-size: 1.3rem;
+  background: rgba(251, 191, 36, 0.15);
+  color: #92400e;
+
+  &[data-tone='warn'] {
+    background: rgba(251, 191, 36, 0.15);
+    color: #92400e;
+  }
+`
+const Stats = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+`
+const StatBubble = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 1.2rem;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+
+  &[data-tone='ok'] {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+  }
+  &[data-tone='warn'] {
+    background: rgba(251, 191, 36, 0.2);
+    color: #92400e;
+  }
+  &[data-tone='info'] {
+    background: rgba(59, 130, 246, 0.1);
+    color: #1d4ed8;
+  }
 `

--- a/pages/guests.tsx
+++ b/pages/guests.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import Button from 'components/Button'
 import Container from 'components/Container'
@@ -38,6 +38,12 @@ export default function GuestsPage() {
     }
   }
 
+  const summary = useMemo(() => {
+    const total = guests.length
+    const withNotes = guests.filter((guest) => guest.notes).length
+    return { total, withNotes }
+  }, [guests])
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!form.name || !form.email) return
@@ -67,6 +73,16 @@ export default function GuestsPage() {
             <SectionTitle>Guests</SectionTitle>
             <Small>Manage your guest list</Small>
           </Header>
+
+          <ActionBar>
+            <Stats>
+              <StatBubble data-tone="ok">Total guests: {summary.total}</StatBubble>
+              <StatBubble data-tone="info">With notes: {summary.withNotes}</StatBubble>
+            </Stats>
+            <Button type="button" onClick={load} disabled={loading}>
+              {loading ? 'Refreshing…' : 'Refresh list'}
+            </Button>
+          </ActionBar>
 
           <Card>
             <CardTitle>Add Guest</CardTitle>
@@ -135,6 +151,15 @@ const Header = styled.div`
   margin-bottom: 1.5rem;
 `
 
+const ActionBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+`
+
 const Small = styled.p`
   opacity: 0.7;
 `
@@ -200,4 +225,28 @@ const GuestNotes = styled.div`
   margin-top: 0.5rem;
   font-size: 1.3rem;
   opacity: 0.7;
+`
+
+const Stats = styled.div`
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+`
+
+const StatBubble = styled.span`
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 1.2rem;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+
+  &[data-tone='ok'] {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+  }
+
+  &[data-tone='info'] {
+    background: rgba(59, 130, 246, 0.1);
+    color: #1d4ed8;
+  }
 `

--- a/pages/rooms.tsx
+++ b/pages/rooms.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
+import Button from 'components/Button'
 import Container from 'components/Container'
 import SectionTitle from 'components/SectionTitle'
 
@@ -30,10 +31,25 @@ export default function RoomsPage() {
     }
   }
 
+  const summary = useMemo(() => {
+    if (!rooms.length) return { total: 0, beds: 0 }
+    const totalBeds = rooms.reduce((sum, room) => sum + (room.beds?.length ?? 0), 0)
+    return { total: rooms.length, beds: totalBeds }
+  }, [rooms])
+
   return (
       <Container>
         <Wrapper>
           <SectionTitle>Rooms</SectionTitle>
+          <ActionBar>
+            <Stats>
+              <StatBubble data-tone="ok">Rooms: {summary.total}</StatBubble>
+              <StatBubble data-tone="info">Beds: {summary.beds}</StatBubble>
+            </Stats>
+            <Button type="button" onClick={load} disabled={loading}>
+              {loading ? 'Refreshing…' : 'Refresh list'}
+            </Button>
+          </ActionBar>
           {loading ? (
             <Small>Loading rooms...</Small>
           ) : error ? (
@@ -67,6 +83,15 @@ export default function RoomsPage() {
 
 const Wrapper = styled.div`
   padding: 2rem 0;
+`
+
+const ActionBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 `
 const Small = styled.p`
   opacity: 0.7;
@@ -113,4 +138,28 @@ const BedTag = styled.span`
   border-radius: 0.4rem;
   padding: 0.2rem 0.6rem;
   font-size: 1.2rem;
+`
+
+const Stats = styled.div`
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+`
+
+const StatBubble = styled.span`
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  font-size: 1.2rem;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+
+  &[data-tone='ok'] {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+  }
+
+  &[data-tone='info'] {
+    background: rgba(59, 130, 246, 0.1);
+    color: #1d4ed8;
+  }
 `


### PR DESCRIPTION
## Summary
- add live stats and refresh controls to bookings, guests, and rooms pages
- highlight pending bookings with an action callout for faster follow-up
- update sprint session log with the UI improvements

## Testing
- npm run lint
- manual: bookings/guests/rooms refresh updates list after imports
- manual: pending booking displays "Action needed" callout
